### PR TITLE
Add JEI support for workstump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ build/
 bin/
 .gradle/
 .idea
+run/
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ $RECYCLE.BIN/
 .TemporaryItems
 .Trashes
 .VolumeIcon.icns
+*.iml
 
 # Directories potentially created on remote AFP share
 .AppleDB
@@ -48,3 +49,4 @@ Temporary Items
 build/
 bin/
 .gradle/
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ repositories {
 }
 
 dependencies {
-    deobfCompile "mezz.jei:jei_1.12.2:4.8.5.133"
+    deobfCompile "mezz.jei:jei_1.12.2:4.9.1.169"
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.0.9.289"
 }
 

--- a/src/main/java/primal_tech/jei/JEIPluginWorkstump.java
+++ b/src/main/java/primal_tech/jei/JEIPluginWorkstump.java
@@ -1,0 +1,58 @@
+package primal_tech.jei;
+
+import mezz.jei.api.*;
+import mezz.jei.api.recipe.IRecipeCategoryRegistration;
+import mezz.jei.plugins.vanilla.crafting.CraftingRecipeChecker;
+import mezz.jei.plugins.vanilla.crafting.ShapedOreRecipeWrapper;
+import mezz.jei.plugins.vanilla.crafting.ShapedRecipesWrapper;
+import mezz.jei.plugins.vanilla.crafting.ShapelessRecipeWrapper;
+import net.minecraft.client.gui.inventory.GuiCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+import primal_tech.ModBlocks;
+import primal_tech.jei.workstump.WorkStumpCategory;
+import primal_tech.jei.workstump.WorkStumpIICategory;
+
+@JEIPlugin
+public class JEIPluginWorkstump
+    implements IModPlugin {
+
+  @Override
+  public void registerCategories(IRecipeCategoryRegistration registry) {
+
+    IJeiHelpers jeiHelpers = registry.getJeiHelpers();
+    IGuiHelper guiHelper = jeiHelpers.getGuiHelper();
+
+    registry.addRecipeCategories(
+        new WorkStumpCategory(guiHelper),
+        new WorkStumpIICategory(guiHelper)
+    );
+  }
+
+  @Override
+  public void register(IModRegistry registry) {
+
+    IJeiHelpers jeiHelpers = registry.getJeiHelpers();
+
+    this.create(registry, jeiHelpers, WorkStumpCategory.UID);
+    registry.addRecipeCatalyst(new ItemStack(ModBlocks.WORK_STUMP), WorkStumpCategory.UID);
+
+    this.create(registry, jeiHelpers, WorkStumpIICategory.UID);
+    registry.addRecipeCatalyst(new ItemStack(ModBlocks.WORK_STUMP_II), WorkStumpIICategory.UID);
+  }
+
+  private void create(IModRegistry registry, IJeiHelpers jeiHelpers, String uid) {
+
+    registry.addRecipes(CraftingRecipeChecker.getValidRecipes(jeiHelpers), uid);
+
+    registry.handleRecipes(ShapedOreRecipe.class, recipe -> new ShapedOreRecipeWrapper(jeiHelpers, recipe), uid);
+    registry.handleRecipes(ShapedRecipes.class, recipe -> new ShapedRecipesWrapper(jeiHelpers, recipe), uid);
+    registry.handleRecipes(ShapelessOreRecipe.class, recipe -> new ShapelessRecipeWrapper<>(jeiHelpers, recipe), uid);
+    registry.handleRecipes(ShapelessRecipes.class, recipe -> new ShapelessRecipeWrapper<>(jeiHelpers, recipe), uid);
+
+    registry.addRecipeClickArea(GuiCrafting.class, 88, 32, 28, 23, uid);
+  }
+}

--- a/src/main/java/primal_tech/jei/workstump/WorkStumpCategory.java
+++ b/src/main/java/primal_tech/jei/workstump/WorkStumpCategory.java
@@ -1,0 +1,48 @@
+package primal_tech.jei.workstump;
+
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.plugins.vanilla.crafting.CraftingRecipeCategory;
+import mezz.jei.util.Translator;
+import net.minecraft.item.ItemStack;
+import primal_tech.ModBlocks;
+
+public class WorkStumpCategory
+    extends CraftingRecipeCategory {
+
+  public static final String UID = "primal_tech.workstump";
+
+  private final String localizedName;
+  private final IDrawable icon;
+
+  public WorkStumpCategory(IGuiHelper guiHelper) {
+
+    super(guiHelper);
+    this.localizedName = Translator.translateToLocal("tile.primal_tech.work_stump.name");
+    this.icon = guiHelper.createDrawableIngredient(new ItemStack(ModBlocks.WORK_STUMP));
+  }
+
+  @Override
+  public String getModName() {
+
+    return "Primal Tech";
+  }
+
+  @Override
+  public String getTitle() {
+
+    return this.localizedName;
+  }
+
+  @Override
+  public String getUid() {
+
+    return UID;
+  }
+
+  @Override
+  public IDrawable getIcon() {
+
+    return this.icon;
+  }
+}

--- a/src/main/java/primal_tech/jei/workstump/WorkStumpIICategory.java
+++ b/src/main/java/primal_tech/jei/workstump/WorkStumpIICategory.java
@@ -1,0 +1,48 @@
+package primal_tech.jei.workstump;
+
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.plugins.vanilla.crafting.CraftingRecipeCategory;
+import mezz.jei.util.Translator;
+import net.minecraft.item.ItemStack;
+import primal_tech.ModBlocks;
+
+public class WorkStumpIICategory
+    extends CraftingRecipeCategory {
+
+  public static final String UID = "primal_tech.workstump.upgraded";
+
+  private final String localizedName;
+  private final IDrawable icon;
+
+  public WorkStumpIICategory(IGuiHelper guiHelper) {
+
+    super(guiHelper);
+    this.localizedName = Translator.translateToLocal("tile.primal_tech.work_stump_upgraded.name");
+    this.icon = guiHelper.createDrawableIngredient(new ItemStack(ModBlocks.WORK_STUMP_II));
+  }
+
+  @Override
+  public String getModName() {
+
+    return "Primal Tech";
+  }
+
+  @Override
+  public String getTitle() {
+
+    return this.localizedName;
+  }
+
+  @Override
+  public String getUid() {
+
+    return UID;
+  }
+
+  @Override
+  public IDrawable getIcon() {
+
+    return this.icon;
+  }
+}


### PR DESCRIPTION
As of JEI v4.9.0, recipe categories are hidden when all their crafting catalysts are hidden. This means that if the vanilla crafting table is hidded, with gamestages for example, no 3x3 crafting recipes will be shown in JEI, even if the workstump is available.

This PR aims to rectify that issue by providing JEI support for the workstump.

The gradle build file has been updated to reflect the latest version of JEI and a couple of lines were added to the .gitignore file.